### PR TITLE
Removes global variables from mii single thread

### DIFF
--- a/app_bridge_errors/Makefile
+++ b/app_bridge_errors/Makefile
@@ -1,0 +1,12 @@
+TARGET = XC-3
+APP_NAME =
+XCC_FLAGS = -g -Os -fsubword-select
+USED_MODULES = module_mii_singlethread
+
+
+#=============================================================================
+# The following part of the Makefile includes the common build infrastructure
+# for compiling XMOS applications. You should not need to edit below here.
+
+XMOS_MAKE_PATH ?= ../..
+include $(XMOS_MAKE_PATH)/xcommon/module_xcommon/build/Makefile.common

--- a/app_bridge_errors/src/main.xc
+++ b/app_bridge_errors/src/main.xc
@@ -1,0 +1,132 @@
+// Copyright (c) 2011, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+
+#include <xs1.h>
+#include <xclib.h>
+#include <stdio.h>
+#include <print.h>
+#include <platform.h>
+#include <stdlib.h>
+#include "miiClient.h"
+#include "miiDriver.h"
+
+
+on stdcore[2]: mii_interface_t mii0 =
+  {
+    XS1_CLKBLK_1, XS1_CLKBLK_2,
+    PORT_ETH_RXCLK_0, PORT_ETH_RXER_0, PORT_ETH_RXD_0, PORT_ETH_RXDV_0,
+    PORT_ETH_TXCLK_0, PORT_ETH_TXEN_0, PORT_ETH_TXD_0,
+    XS1_PORT_8A,
+  };
+
+on stdcore[2]: mii_interface_t mii1 =
+  {
+    XS1_CLKBLK_3, XS1_CLKBLK_4,
+    PORT_ETH_RXCLK_1, PORT_ETH_RXER_1, PORT_ETH_RXD_1, PORT_ETH_RXDV_1,
+    PORT_ETH_TXCLK_1, PORT_ETH_TXEN_1, PORT_ETH_TXD_1,
+    XS1_PORT_8B,
+  };
+
+on stdcore[2]: out port p_mii_resetn = PORT_ETH_RST_N;
+on stdcore[2]: smi_interface_t smi0 = { PORT_ETH_MDIO_0, PORT_ETH_MDC_0, 0 };
+on stdcore[2]: smi_interface_t smi1 = { PORT_ETH_MDIO_1, PORT_ETH_MDC_1, 0 };
+
+on stdcore[2]: clock clk_smi = XS1_CLKBLK_5;
+
+void txrx(chanend cIn, chanend cOut, chanend cNotifications,
+          streaming chanend packetTx, streaming chanend packetRx) {
+    int b[3200];
+    int txbuf[400];
+    struct miiData miiData;
+    int length;
+
+    printstr("Test started\n");
+    miiBufferInit(miiData, cIn, cNotifications, b, 3200);
+    miiOutInit(cOut);
+    
+    while (1) {
+        int nBytes, a, timeStamp;
+        select {
+        case miiNotified(miiData, cNotifications);
+        case packetTx :> length:
+            for(int i = 0; i <= (length >> 2); i++) {
+                packetTx :> txbuf[i];
+            }
+            miiOutPacket(cOut, txbuf, 0, length);
+            miiOutPacketDone(cOut);
+            break;
+        }
+        while(1) {
+            {a,nBytes,timeStamp} = miiGetInBuffer(miiData);
+
+            if (a == 0) {
+                break;
+            }
+            packetRx <: nBytes;
+            for(int i = 0; i <= (nBytes >> 2); i++) {
+                int v;
+                asm("ldw %0, %1[%2]" : "=r" (v) : "r" (a), "r" (i));
+                packetRx <: v;
+            }
+            miiFreeInBuffer(miiData, a);
+        }
+        miiRestartBuffer(miiData);
+    } 
+}
+
+static void buffer(streaming chanend tx, streaming chanend rx) {
+    int buf[400];
+    int length;
+    unsigned int random = 0;
+
+    while(1) {
+        select {
+        case rx :> length:
+            for(int i = 0; i <= (length >> 2); i++) {
+                rx :> buf[i];
+            }
+            crc32(random, ~length, 0xEDB88320);
+            if ((random & 7) == 0) {
+                buf[8] ^= 0xAAAAAAAA;
+            }
+            tx <: length;
+            for(int i = 0; i <= (length >> 2); i++) {
+                tx <: buf[i];
+            }
+            crc32(random, ~length, 0xEDB88320);
+            if ((random & 7) == 0) {
+                tx <: length;
+                for(int i = 0; i <= (length >> 2); i++) {
+                    tx <: buf[i];
+                }
+            }
+            break;
+        }
+    }
+}
+
+int main() {
+    chan cIn0, cOut0;
+    chan cIn1, cOut1;
+    chan notifications0;
+    chan notifications1;
+    streaming chan from0, to0, from1, to1;
+    par {
+        on stdcore[2]: {
+        	miiInitialise(clk_smi, p_mii_resetn, smi0, mii0);
+        	miiInitialise(clk_smi, p_mii_resetn, smi1, mii1);
+            par {
+                miiDriver(mii0, cIn0, cOut0);
+                miiDriver(mii1, cIn1, cOut1);
+            }
+        }
+        on stdcore[2]: txrx(cIn0, cOut0, notifications0, from1, to1);
+        on stdcore[2]: txrx(cIn1, cOut1, notifications1, from0, to0);
+        on stdcore[0]: buffer(from0, to1);
+        on stdcore[0]: buffer(from1, to0);
+    }
+	return 0;
+}

--- a/module_mii_singlethread/src/miiClientInterrupt.S
+++ b/module_mii_singlethread/src/miiClientInterrupt.S
@@ -25,46 +25,38 @@
 .linkset miiInstallHandler.maxsync, 0
 
 .globl miiInstallHandler
-.globl systemWr
-    .globl miiPacketsTransmitted
-    .globl miiPacketsReceived
-    .globl miiPacketsCRCError
-    .globl miiPacketsOverran
 
-    .section .dp.bss,        "adw", @nobits
+#define nextBuffer                0
+#define packetInLLD               1
+#define notificationChannelEnd    2
+#define miiChannelEnd             3
+#define miiPacketsOverran         4
+#define kernelStackEnd            148
 
-packetInLLD:    
-    .space 4
-interruptChannelEnd:
-    .space 4
-blockingChannel:
-    .space 4
-kernelStack:
-    .space KERNEL_STACK_SAVE * 4 + 128 // TODO: miiClientUser.nstackwords
-kernelStackEnd:
-    .space 4
-    .text
-
+    
     .align 4
 miiInstallHandler:
-    setd   res[r2], r2                //    synchronising interrupt routine and user land
-    stw    r2, dp[blockingChannel]    //    it points to itself
+    setd   res[r3], r3                //    synchronising interrupt routine and user land
+    stw    r3, r0[notificationChannelEnd]    //    it points to itself
 
-    stw    r1, dp[interruptChannelEnd]// Step 2: Channel end to MIILLD layer, store it
+    stw    r2, r0[miiChannelEnd]   // Step 2: Channel end to MIILLD layer, store it
     ldap   r11, miiInterruptHandler   //         and set it up for interrupts.
-    setc   res[r1], XS1_SETC_IE_MODE_INTERRUPT
-    setv   res[r1], r11
-    eeu    res[r1]
+    setc   res[r2], XS1_SETC_IE_MODE_INTERRUPT
+    setv   res[r2], r11
+    eeu    res[r2]
+    or     r11, r0, r0
+    setev  res[r2], r11
 
-    ldaw   r1, dp[kernelStackEnd]     // Step 5: Set up kernel stack.
-    ldaw   r11, sp[0]                  //         Save SP into R1
-    set    sp, r1	                  //         Set SP, and place old SP...
+    ldc    r3, kernelStackEnd
+    ldaw   r2, r0[r3]                  // Step 5: Set up kernel stack.
+    ldaw   r11, sp[0]                  //         Save SP into R2
+    set    sp, r2	                   //         Set SP, and place old SP...
     stw    r11, sp[0]                  //         ...where KRESTSP expects it
-    krestsp 0	                      //         Set KSP, restore SP
+    krestsp 0	                       //         Set KSP, restore SP
 
-    ldw    r1, dp[interruptChannelEnd]// Step 6: provide LLD with first buffer
-    out    res[r1], r0
-    stw    r0, dp[packetInLLD]        //         packetInLLD holds pointer passed to LLD.
+    ldw    r2, r0[miiChannelEnd]   // Step 6: provide LLD with first buffer
+    out    res[r2], r1
+    stw    r1, r0[packetInLLD]        //         packetInLLD holds pointer passed to LLD.
     
     setsr  IEBLE                      // Step 7: Enable interrupts!
     retsp  0
@@ -74,45 +66,48 @@ miiInstallHandler:
     .align 4
 miiInterruptHandler:
     kentsp KERNEL_STACK_SAVE
-    stw    r2, sp[3] 
+    stw    r3, sp[4] 
+    stw    r2, sp[3]
+    stw    r11, sp[5] 
+
+    get    r11, ed
+    ldw    r3, r11[miiChannelEnd]
+    in     r2, res[r3]               // Watch out: the number of instructions between interrupt and out should be
+                                     // no less than 10, no more than 40.
     stw    r1, sp[2]
     
-    ldw    r2, dp[interruptChannelEnd]
-    in     r1, res[r2]               // Watch out: the number of instructions between interrupt and out should be
-                                     // no less than 10, no more than 40.
-    stw    r0, sp[1]
     
-    
-    ldc    r0, 0   
-    out    res[r2], r0
+    ldc    r1, 0   
+    out    res[r3], r1
 
-    stw    r3, sp[4] 
-    stw    r11, sp[5] 
+    stw    r0, sp[1] 
     stw    lr, sp[6]
+    or     r0, r11, r11
     nop
     nop
     nop
     nop
     nop
 
-    ldw    r0, dp[packetInLLD]
-    ldw    r3, dp[nextBuffer]
+    ldw    r1, r0[packetInLLD]
+    ldw    r11, r0[nextBuffer]
 
-    add    r11, r3, 1
+    add    r11, r11, 1
     bt     r11, buffersAvailable
-    out    res[r2], r0               // Reuse this buffer - drop current packet.
-    ldw   r2, dp[miiPacketsOverran]
-    add   r2, r2, 1
-    stw   r2, dp[miiPacketsOverran]
+    out    res[r3], r1               // Reuse this buffer - drop current packet.
+    ldw   r3, r0[miiPacketsOverran]
+    add   r3, r3, 1
+    stw   r3, r0[miiPacketsOverran]
     bu     returnFromInterrupt
 buffersAvailable:
-
-    out    res[r2], r3               // Pass fresh buffer.
-    stw    r3, dp[packetInLLD]
-    ldw    r2, dp[blockingChannel]
-    // r0: base
-    // r1: end
-    // r2: blockingChannel
+    sub    r11, r11, 1
+    out    res[r3], r11               // Pass fresh buffer.
+    stw    r11, r0[packetInLLD]
+    ldw    r3, r0[notificationChannelEnd]
+    // r0: struct
+    // r1: base
+    // r2: end
+    // r3: notificationChannelEnd
     bl     miiClientUser
     
 returnFromInterrupt:    

--- a/module_mii_singlethread/src/miiClientUser.xc
+++ b/module_mii_singlethread/src/miiClientUser.xc
@@ -11,13 +11,8 @@
 
 #define POLY   0xEDB88320
 
-int miiPacketsCRCError;
-int miiPacketsReceived;
-int miiPacketsOverran;
-int miiPacketsTransmitted;
-int nextBuffer;
-
-extern void miiInstallHandler(int bufferAddr,
+extern void miiInstallHandler(struct miiData &this,
+                              int bufferAddr,
                               chanend miiChannel,
                               chanend notificationChannel);
 
@@ -55,15 +50,15 @@ static int CRCBad(int base, int end) {
     return ~partCRC == 0 ? length : 0;
 }
 
-static int packetGood(int base, int end) {
+static int packetGood(struct miiData &this, int base, int end) {
     int length = CRCBad(base, end);
 
     if (length == 0) {
-        miiPacketsCRCError++;
+        this.miiPacketsCRCError++;
         return 0;
     }
     // insert MAC filter here.
-    miiPacketsReceived++;
+    this.miiPacketsReceived++;
     return length;
 }
 
@@ -88,8 +83,6 @@ static int packetGood(int base, int end) {
  * pointer either points to enough free space to allocate a buffer, or it
  * sits too close to the free pointer for there to be room for a packet.
  */
- 
-static int freePtr[2], wrPtr[2], lastSafePtr[2], firstPtr[2], readPtr[2];
 
 /* packetInLLD (maintained by the LLD) remembers which buffer is being
  * filled right now; nextBuffer (maintained byt ClientUser.xc) stores which
@@ -101,8 +94,6 @@ static int freePtr[2], wrPtr[2], lastSafePtr[2], firstPtr[2], readPtr[2];
  * leave nextBuffer to point to a fresh buffer.
  */
 
-int nextBuffer;
-static int refillBankNumber;
 #define MAXPACKET 1530
 
 static void set(int addr, int value) {
@@ -117,55 +108,58 @@ static int get(int addr) {
 
 /* Called once on startup */
 
-void miiBufferInit(chanend cIn, chanend cNotifications, int buffer[], int numberWords) {
+void miiBufferInit(struct miiData &this, chanend cIn, chanend cNotifications, int buffer[], int numberWords) {
     int address;
+    this.notifySeen = 1;
+    this.notifyLast = 1;
     asm("add %0, %1, 0" : "=r" (address) : "r" (buffer));
-    readPtr[0] = firstPtr[0] = freePtr[0] = address ;
-    readPtr[1] = firstPtr[1] = freePtr[1] = address + ((numberWords << 1) & ~3) ;
-    wrPtr[0] = freePtr[0] + 4;
-    wrPtr[1] = freePtr[1] + 4;
-    set(freePtr[0], 1);
-    set(freePtr[1], 1);
-    lastSafePtr[0] = freePtr[1] - MAXPACKET;
-    lastSafePtr[1] = address + (numberWords << 2) - MAXPACKET;
-    nextBuffer    = wrPtr[1];
-    miiInstallHandler(wrPtr[0], cIn, cNotifications);
+    this.readPtr[0] = this.firstPtr[0] = this.freePtr[0] = address ;
+    this.readPtr[1] = this.firstPtr[1] = this.freePtr[1] = address + ((numberWords << 1) & ~3) ;
+    this.wrPtr[0] = this.freePtr[0] + 4;
+    this.wrPtr[1] = this.freePtr[1] + 4;
+    set(this.freePtr[0], 1);
+    set(this.freePtr[1], 1);
+    this.lastSafePtr[0] = this.freePtr[1] - MAXPACKET;
+    this.lastSafePtr[1] = address + (numberWords << 2) - MAXPACKET;
+    this.nextBuffer    = this.wrPtr[1];
+    this.miiPacketsOverran = 0;
+    this.refillBankNumber = 0;
+    this.miiPacketsTransmitted = 0;
+    this.miiPacketsReceived = 0;
+    this.miiPacketsCRCError = 0;
+    this.readBank = 0;
+    miiInstallHandler(this, this.wrPtr[0], cIn, cNotifications);
 }
 
 
 /* Called from interrupt handler */
 
-static char notifyLast = 1;
-char notifySeen = 1;
-
-void miiNotify(chanend notificationChannel) {
-    if (notifyLast == notifySeen) {
-        notifyLast = !notifyLast;
-        outuchar(notificationChannel, notifyLast);
+void miiNotify(struct miiData &this, chanend notificationChannel) {
+    if (this.notifyLast == this.notifySeen) {
+        this.notifyLast = !this.notifyLast;
+        outuchar(notificationChannel, this.notifyLast);
     }
 }
 
-select miiNotified(chanend notificationChannel) {
-case inuchar_byref(notificationChannel, notifySeen):
+select miiNotified(struct miiData &this, chanend notificationChannel) {
+case inuchar_byref(notificationChannel, this.notifySeen):
     break;
 }
 
-static int readBank = 0;
-
-{unsigned, unsigned, unsigned} miiGetInBuffer() {
+{unsigned, unsigned, unsigned} miiGetInBuffer(struct miiData &this) {
     unsigned nBytes, timeStamp;
     for(int i = 0; i < 2; i++) {
-        readBank = !readBank;
-        nBytes = get(readPtr[readBank]);
+        this.readBank = !this.readBank;
+        nBytes = get(this.readPtr[this.readBank]);
         if (nBytes == 0) {
-            readPtr[readBank] = firstPtr[readBank];
-            nBytes = get(readPtr[readBank]);
+            this.readPtr[this.readBank] = this.firstPtr[this.readBank];
+            nBytes = get(this.readPtr[this.readBank]);
         }
         if (nBytes != 1) {
-            unsigned retVal = readPtr[readBank] + 4;
-            readPtr[readBank] += ((nBytes + 3) & ~3) + 4;
-            if (get(readPtr[readBank]) == 0) {
-                readPtr[readBank] = firstPtr[readBank];
+            unsigned retVal = this.readPtr[this.readBank] + 4;
+            this.readPtr[this.readBank] += ((nBytes + 3) & ~3) + 4;
+            if (get(this.readPtr[this.readBank]) == 0) {
+                this.readPtr[this.readBank] = this.firstPtr[this.readBank];
             }
             timeStamp = get(retVal);
             return {retVal+4, nBytes-4, timeStamp};
@@ -174,79 +168,79 @@ static int readBank = 0;
     return {0, 0, 0};
 }
 
-static void miiCommitBuffer(unsigned int currentBuffer, unsigned int length, chanend notificationChannel) {
-    int bn = currentBuffer < firstPtr[1] ? 0 : 1;    
-    set(wrPtr[bn]-4, length);       // record length of current packet.
-    wrPtr[bn] = wrPtr[bn] + ((length+3)&~3) + 4; // new end pointer.
-    miiNotify(notificationChannel);
-    if (wrPtr[bn] > lastSafePtr[bn]) {  // This may be too far.
-        if (freePtr[bn] != firstPtr[bn]) {// Test if head of buf is free
-            set(wrPtr[bn]-4, 0);          // If so, record unused tail.
-            wrPtr[bn] = firstPtr[bn] + 4; // and wrap to head, and record that
-            set(wrPtr[bn]-4, 1);          // this is now the head of the queue.
-            if (freePtr[bn] - wrPtr[bn] >= MAXPACKET) {// Test if there is room for packet
-                nextBuffer = wrPtr[bn];     // if so, record packet pointer
+static void miiCommitBuffer(struct miiData &this, unsigned int currentBuffer, unsigned int length, chanend notificationChannel) {
+    int bn = currentBuffer < this.firstPtr[1] ? 0 : 1;    
+    set(this.wrPtr[bn]-4, length);       // record length of current packet.
+    this.wrPtr[bn] = this.wrPtr[bn] + ((length+3)&~3) + 4; // new end pointer.
+    miiNotify(this, notificationChannel);
+    if (this.wrPtr[bn] > this.lastSafePtr[bn]) {  // This may be too far.
+        if (this.freePtr[bn] != this.firstPtr[bn]) {// Test if head of buf is free
+            set(this.wrPtr[bn]-4, 0);          // If so, record unused tail.
+            this.wrPtr[bn] = this.firstPtr[bn] + 4; // and wrap to head, and record that
+            set(this.wrPtr[bn]-4, 1);          // this is now the head of the queue.
+            if (this.freePtr[bn] - this.wrPtr[bn] >= MAXPACKET) {// Test if there is room for packet
+                this.nextBuffer = this.wrPtr[bn];     // if so, record packet pointer
                 return;                            // fall out - default is no room
             }
         } else {
-            set(wrPtr[bn]-4, 1);          // this is still the head of the queue.
+            set(this.wrPtr[bn]-4, 1);          // this is still the head of the queue.
         }
     } else {                                       // room in tail.
-        set(wrPtr[bn]-4, 1);            // record that this is now the head of the queue.
-        if (wrPtr[bn] > freePtr[bn] || // Test if there is room for a packet
-            freePtr[bn] - wrPtr[bn] >= MAXPACKET) {
-            nextBuffer = wrPtr[bn];           // if so, record packet pointer
+        set(this.wrPtr[bn]-4, 1);            // record that this is now the head of the queue.
+        if (this.wrPtr[bn] > this.freePtr[bn] || // Test if there is room for a packet
+            this.freePtr[bn] - this.wrPtr[bn] >= MAXPACKET) {
+            this.nextBuffer = this.wrPtr[bn];           // if so, record packet pointer
             return;
         }
     }
-    nextBuffer = -1;                             // buffer full - no more room for data.
-    refillBankNumber = bn;
+    this.nextBuffer = -1;                             // buffer full - no more room for data.
+    this.refillBankNumber = bn;
     return;
 }
 
-static void miiRejectBuffer(unsigned int currentBuffer) {
-    nextBuffer = currentBuffer;
+static void miiRejectBuffer(struct miiData &this, unsigned int currentBuffer) {
+    this.nextBuffer = currentBuffer;
 }
 
-void miiRestartBuffer() {
+void miiRestartBuffer(struct miiData &this) {
     int bn;
-    if (nextBuffer != -1) {
+    if (this.nextBuffer != -1) {
         return;
     }
-    bn = refillBankNumber;
+    bn = this.refillBankNumber;
 
-    if (wrPtr[bn] > lastSafePtr[bn]) {  // This may be too far.
-        if (freePtr[bn] != firstPtr[bn]) {// Test if head of buf is free
-            set(wrPtr[bn]-4, 0);          // If so, record unused tail.
-            wrPtr[bn] = firstPtr[bn] + 4; // and wrap to head, and record that
-            set(wrPtr[bn]-4, 1);          // this is now the head of the queue.
-            if (freePtr[bn] - wrPtr[bn] >= MAXPACKET) {// Test if there is room for packet
-                nextBuffer = wrPtr[bn];     // if so, record packet pointer
+    if (this.wrPtr[bn] > this.lastSafePtr[bn]) {  // This may be too far.
+        if (this.freePtr[bn] != this.firstPtr[bn]) {// Test if head of buf is free
+            set(this.wrPtr[bn]-4, 0);          // If so, record unused tail.
+            this.wrPtr[bn] = this.firstPtr[bn] + 4; // and wrap to head, and record that
+            set(this.wrPtr[bn]-4, 1);          // this is now the head of the queue.
+            if (this.freePtr[bn] - this.wrPtr[bn] >= MAXPACKET) {// Test if there is room for packet
+                this.nextBuffer = this.wrPtr[bn];     // if so, record packet pointer
             }
         }
     } else {                                       // room in tail.
-        if (wrPtr[bn] > freePtr[bn] || // Test if there is room for a packet
-            freePtr[bn] - wrPtr[bn] >= MAXPACKET) {
-            nextBuffer = wrPtr[bn];           // if so, record packet pointer
+        if (this.wrPtr[bn] > this.freePtr[bn] || // Test if there is room for a packet
+            this.freePtr[bn] - this.wrPtr[bn] >= MAXPACKET) {
+            this.nextBuffer = this.wrPtr[bn];           // if so, record packet pointer
         }
     }
 }
 
-void miiFreeInBuffer(int base) {
-    int bankNumber = base < firstPtr[1] ? 0 : 1;
+void miiFreeInBuffer(struct miiData &this, int base) {
+    int bankNumber = base < this.firstPtr[1] ? 0 : 1;
     int modifiedFreePtr = 0;
     base -= 4;
     set(base-4, -get(base-4));
     while (1) {
-        int l = get(freePtr[bankNumber]);
+        int l = get(this.freePtr[bankNumber]);
         if (l > 0) {
             break;
         }
         modifiedFreePtr = 1;
         if (l == 0) {
-            freePtr[bankNumber] = firstPtr[bankNumber];
+            this.freePtr[bankNumber] = this.firstPtr[bankNumber];
         } else {
-            freePtr[bankNumber] += (((-l) + 3) & ~3) + 4;
+            this.freePtr[bankNumber] += (((-l) + 3) & ~3) + 4;
         }
     }
     // Note - wrptr may have been stuck
@@ -260,12 +254,12 @@ void miiTimeStampInit(unsigned offset) {
     globalOffset = (offset + testOffset) & 0x3FFFF;
 }
 
-void miiClientUser(int base, int end, chanend notificationChannel) {
-    int length = packetGood(base, end);
+void miiClientUser(struct miiData &this, int base, int end, chanend notificationChannel) {
+    int length = packetGood(this, base, end);
     if (length != 0) {
-        miiCommitBuffer(base, length, notificationChannel);
+        miiCommitBuffer(this, base, length, notificationChannel);
     } else {
-        miiRejectBuffer(base);
+        miiRejectBuffer(this, base);
     }
 }
 

--- a/module_mii_singlethread/src/miiLLD.S
+++ b/module_mii_singlethread/src/miiLLD.S
@@ -198,10 +198,6 @@ mii_rxd_preamble:
     
     // Idle state, wait for a packet
 stateIdle:
-    ldw   r5, dp[miiPacketsTransmitted]
-    add   r5, r5, 1            // Record that we transmitted a packet
-    stw   r5, dp[miiPacketsTransmitted]
-
     ldw   r5, sp[timingPort]    // Create interframe gap
     getts r7, res[r5]           // Get current count on timing port
     ldc   r8, 90                // Add 90 (960 ns nibbles - but we will have lost 60ns)


### PR DESCRIPTION
This enables multiple instances in a single core; for example the bridging example.

Warning - this feature slightly changes the interface, and requires a struct to be passed to many mii functions.
