### PR TITLE
Make use of inline C99 compliant

### DIFF
--- a/module_ethernet/src/server/mii.h
+++ b/module_ethernet/src/server/mii.h
@@ -141,28 +141,24 @@ typedef struct mii_packet_t {
 #define STRINGIFY0(x) #x
 #define STRINGIFY(x) STRINGIFY0(x)
 
-
-
-#ifdef __XC__
-
 #ifdef ETHERNET_INLINE_PACKET_GET
 // The inline assembler version of the Get breaks.  Use a C function until
 // a tools fix is available
 #define create_buf_getset(field) \
   inline int mii_packet_get_##field (int buf) { \
     int x; \
-    asm("ldw %0,%1[" STRINGIFY(BUF_OFFSET_ ## field) "]":"=r"(x):"r"(buf)); \
+    __asm__("ldw %0,%1[" STRINGIFY(BUF_OFFSET_ ## field) "]":"=r"(x):"r"(buf)); \
     return x; \
  } \
  inline void mii_packet_set_##field (int buf, int x) { \
-  asm("stw %1, %0[" STRINGIFY(BUF_OFFSET_ ## field) "]"::"r"(buf),"r"(x)); \
+  __asm__("stw %1, %0[" STRINGIFY(BUF_OFFSET_ ## field) "]"::"r"(buf),"r"(x)); \
  }
 #else
 // Temporary version of the get/set to avoid compiler issue with inline assembler
 #define create_buf_getset(field) \
  int mii_packet_get_##field (int buf); \
  inline void mii_packet_set_##field (int buf, int x) { \
-  asm("stw %1, %0[" STRINGIFY(BUF_OFFSET_ ## field) "]"::"r"(buf),"r"(x)); \
+  __asm__("stw %1, %0[" STRINGIFY(BUF_OFFSET_ ## field) "]"::"r"(buf),"r"(x)); \
  }
 #endif
 
@@ -181,13 +177,13 @@ inline int mii_packet_get_data_ptr(int buf) {
 }
 
 inline void mii_packet_set_data_word(int data, int n, int v) {
-  asm("stw %0,%1[%2]"::"r"(v),"r"(data),"r"(n));
+  __asm__("stw %0,%1[%2]"::"r"(v),"r"(data),"r"(n));
 }
 
 #ifdef ETHERNET_INLINE_PACKET_GET
 inline int mii_packet_get_data_word(int data, int n) {
   int x;
-  asm("ldw %0,%1[%2]":"=r"(x):"r"(data),"r"(n));
+  __asm__("ldw %0,%1[%2]":"=r"(x):"r"(data),"r"(n));
   return x;
 }
 #else
@@ -203,7 +199,7 @@ int mii_packet_get_data_word(int data, int n);
 #ifdef ETHERNET_INLINE_PACKET_GET
 inline int mii_packet_get_data(int buf, int n) {
   int x;
-  asm("ldw %0,%1[%2]":"=r"(x):"r"(buf),"r"(n+BUF_DATA_OFFSET));
+  __asm__("ldw %0,%1[%2]":"=r"(x):"r"(buf),"r"(n+BUF_DATA_OFFSET));
   return x;
 }
 #else
@@ -211,16 +207,12 @@ int mii_packet_get_data(int buf, int n);
 #endif
 
 inline void mii_packet_set_data(int buf, int n, int v) {
-  asm("stw %0,%1[%2]"::"r"(v),"r"(buf),"r"(n+BUF_DATA_OFFSET));
+  __asm__("stw %0,%1[%2]"::"r"(v),"r"(buf),"r"(n+BUF_DATA_OFFSET));
 }
 
 inline void mii_packet_set_data_short(int buf, int n, int v) {
-  asm("st16 %0,%1[%2]"::"r"(v),"r"(buf),"r"(n+(BUF_DATA_OFFSET*2)));
+  __asm__("st16 %0,%1[%2]"::"r"(v),"r"(buf),"r"(n+(BUF_DATA_OFFSET*2)));
 }
-
-
-#endif
-
 
 #ifdef __XC__
 void mii_rx_pins(

--- a/module_ethernet/src/server/mii_malloc.c
+++ b/module_ethernet/src/server/mii_malloc.c
@@ -237,33 +237,3 @@ mii_buffer_t mii_get_my_next_buf(mii_mempool_t mempool, int rdptr0)
 
   return (mii_buffer_t) ((char *) rdptr + sizeof(malloc_hdr_t));
 }
-
-// These are the non-inline implementations of the mii_packet member
-// get functions
-
-int mii_packet_get_data(int buf, int n)
-{
-	return (int)(((mii_packet_t*)buf)->data[n]);
-}
-
-int mii_packet_get_data_word(int data, int n)
-{
-	return ((unsigned int*)data)[n];
-}
-
-#define gen_get_field(field) \
-	int mii_packet_get_##field (int buf) \
-	{ \
-		return ((mii_packet_t*)buf)->field; \
-	}
-
-gen_get_field(length)
-gen_get_field(timestamp)
-gen_get_field(filter_result)
-gen_get_field(src_port)
-gen_get_field(timestamp_id)
-gen_get_field(stage)
-gen_get_field(tcount)
-gen_get_field(crc)
-gen_get_field(forwarding)
-

--- a/module_ethernet/src/server/mii_packet.c
+++ b/module_ethernet/src/server/mii_packet.c
@@ -1,0 +1,53 @@
+// Copyright (c) 2012, XMOS Ltd., All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include "mii.h"
+
+// These are the non-inline implementations of the mii_packet member
+// get functions
+
+#ifdef ETHERNET_INLINE_PACKET_GET
+#define create_buf_getset_external_definition(field) \
+  extern inline int mii_packet_get_##field (int buf); \
+  extern inline void mii_packet_set_##field (int buf, int x);
+#else
+#define create_buf_getset_external_definition(field) \
+  int mii_packet_get_##field (int buf) \
+  { \
+    return ((mii_packet_t*)buf)->field; \
+  } \
+  extern inline void mii_packet_set_##field (int buf, int x);
+#endif
+
+create_buf_getset_external_definition(length)
+create_buf_getset_external_definition(timestamp)
+create_buf_getset_external_definition(filter_result)
+create_buf_getset_external_definition(src_port)
+create_buf_getset_external_definition(timestamp_id)
+create_buf_getset_external_definition(stage)
+create_buf_getset_external_definition(tcount)
+create_buf_getset_external_definition(crc)
+create_buf_getset_external_definition(forwarding)
+
+extern inline int mii_packet_get_data_ptr(int buf);
+extern inline void mii_packet_set_data_word(int data, int n, int v);
+
+#ifdef ETHERNET_INLINE_PACKET_GET
+extern inline int mii_packet_get_data(int buf, int n);
+extern inline int mii_packet_get_data_word(int data, int n);
+#else
+int mii_packet_get_data(int buf, int n)
+{
+  return (int)(((mii_packet_t*)buf)->data[n]);
+}
+
+int mii_packet_get_data_word(int data, int n)
+{
+  return ((unsigned int*)data)[n];
+}
+#endif
+
+extern inline void mii_packet_set_data(int buf, int n, int v);
+extern inline void mii_packet_set_data_short(int buf, int n, int v);

--- a/module_locks/src/swlock.h
+++ b/module_locks/src/swlock.h
@@ -16,7 +16,7 @@ int swlock_try_acquire_xc(swlock_t &lock);
 
 void swlock_acquire_xc(swlock_t &lock);
 
-inline void swlock_release_xc(swlock_t &lock)
+static inline void swlock_release_xc(swlock_t &lock)
 {
   lock = 0;
 }
@@ -27,7 +27,7 @@ int swlock_try_acquire(volatile swlock_t *lock);
 
 void swlock_acquire(volatile swlock_t *lock);
 
-inline void swlock_release(volatile swlock_t *lock)
+static inline void swlock_release(volatile swlock_t *lock)
 {
   *lock = 0;
 }

--- a/test_ethernet_qav/src/mac_custom_filter.h
+++ b/test_ethernet_qav/src/mac_custom_filter.h
@@ -7,7 +7,7 @@
 
 unsigned short get_ethertype(unsigned char buf[]);
 
-inline unsigned int mac_custom_filter(unsigned int data[]){
+static inline unsigned int mac_custom_filter(unsigned int data[]){
 	int mask = FILTER_BROADCAST;
 	unsigned short etype;
 

--- a/test_regression/src/mac_custom_filter.h
+++ b/test_regression/src/mac_custom_filter.h
@@ -7,7 +7,7 @@
 
 unsigned short get_ethertype(unsigned char buf[]);
 
-inline unsigned int mac_custom_filter(unsigned int data[]){
+static inline unsigned int mac_custom_filter(unsigned int data[]){
 	int mask = FILTER_BROADCAST;
 	unsigned short etype;
 


### PR DESCRIPTION
Currently if the compiler decides not to inline one of the functions declared inline without static or extern you will get a link error. This changes declarations in headers to either use static inline or have external definitions in other files.

I've tested that this builds with 11.11.0 and  11.2.2, although I haven't tried running it.
