### PR TITLE
module_ethernet_smi with one fewer clock_block

### DIFF
--- a/app_avb_bridge/Makefile
+++ b/app_avb_bridge/Makefile
@@ -1,0 +1,12 @@
+TARGET = xp-skc-l2-single
+APP_NAME = 
+XCC_FLAGS = -g -O2
+USED_MODULES = module_mii_singlethread module_ethernet_smi module_slicekit_xn
+
+
+#=============================================================================
+# The following part of the Makefile includes the common build infrastructure
+# for compiling XMOS applications. You should not need to edit below here.
+
+XMOS_MAKE_PATH ?= ../..
+include $(XMOS_MAKE_PATH)/xcommon/module_xcommon/build/Makefile.common

--- a/app_avb_bridge/app_description
+++ b/app_avb_bridge/app_description
@@ -1,0 +1,1 @@
+three-port AVB switch: two MII ports, one local port. Feasibility study.

--- a/app_avb_bridge/src/avbManager.h
+++ b/app_avb_bridge/src/avbManager.h
@@ -1,0 +1,6 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+void avbManager(chanend qAVB);

--- a/app_avb_bridge/src/avbManager.xc
+++ b/app_avb_bridge/src/avbManager.xc
@@ -1,0 +1,9 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include "avbManager.h"
+
+void avbManager(chanend qAVB) {
+}

--- a/app_avb_bridge/src/copy.h
+++ b/app_avb_bridge/src/copy.h
@@ -1,0 +1,6 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+void copyManager(chanend inFromMII, chanend queue);

--- a/app_avb_bridge/src/copy.xc
+++ b/app_avb_bridge/src/copy.xc
@@ -1,0 +1,10 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include "copy.h"
+
+void copyManager(chanend inFromMII, chanend queue) {
+    ;
+}

--- a/app_avb_bridge/src/main.xc
+++ b/app_avb_bridge/src/main.xc
@@ -1,4 +1,71 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
 #include <platform.h>
+#include "miiDriver.h"
+#include "smi.h"
+
+#include "copy.h"
+#include "transmitter.h"
+#include "queue.h"
+#include "avbManager.h"
+
+#define SWITCH_CORE 0
+#define AUDIO_CORE  1
+
+on stdcore[SWITCH_CORE]: mii_interface_t miiLeft = {
+    XS1_CLKBLK_1, XS1_CLKBLK_2,
+    PORT_ETH_RXCLK_0, XS1_PORT_16A, PORT_ETH_RXD_0, PORT_ETH_RXDV_0,
+    PORT_ETH_TXCLK_0, PORT_ETH_TXEN_0, PORT_ETH_TXD_0,
+    XS1_PORT_32A,
+};
+
+on stdcore[SWITCH_CORE]: mii_interface_t miiRight = {
+    XS1_CLKBLK_3, XS1_CLKBLK_4,
+    PORT_ETH_RXCLK_1, XS1_PORT_16B, PORT_ETH_RXD_1, PORT_ETH_RXDV_1,
+    PORT_ETH_TXCLK_1, PORT_ETH_TXEN_1, PORT_ETH_TXD_1,
+    XS1_PORT_8B,
+};
+
+on stdcore[SWITCH_CORE]: smi_interface_t smiLeft = {
+    0x80000000,
+    PORT_ETH_MDIOFAKE_0,
+    PORT_ETH_MDIOC_0
+};
+
+on stdcore[SWITCH_CORE]: smi_interface_t smiRight = {
+    0,
+    PORT_ETH_MDIO_1,
+    PORT_ETH_MDC_1
+};
+
+on stdcore[SWITCH_CORE]: clock clk_smi = XS1_CLKBLK_5;
+
+static void ethernetSwitch() {
+    chan cInLeft, cInRight, cOutLeft, cOutRight;
+    chan qLeft, qRight, qTransmit, qAVB;
+    miiInitialise(null, miiLeft);
+    miiInitialise(null, miiRight);
+    par {
+        miiDriver(miiLeft, cInLeft, cOutLeft);
+        miiDriver(miiRight, cInRight, cOutRight);
+        copyManager(cInLeft, qLeft);
+        copyManager(cInRight, qRight);
+        queueManager(qLeft, qRight, qTransmit, qAVB);
+        transmitter(qTransmit, cOutLeft, cOutRight);
+        avbManager(qAVB);
+    }
+}
+
+static void audio() {
+}
 
 int main(void) {
+    par {
+        on stdcore[SWITCH_CORE]: ethernetSwitch();
+        on stdcore[AUDIO_CORE]: audio();
+    }
+    return 0;
 }

--- a/app_avb_bridge/src/main.xc
+++ b/app_avb_bridge/src/main.xc
@@ -1,0 +1,4 @@
+#include <platform.h>
+
+int main(void) {
+}

--- a/app_avb_bridge/src/queue.h
+++ b/app_avb_bridge/src/queue.h
@@ -1,0 +1,7 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+void queueManager(chanend qLeft, chanend qRight,
+                  chanend qTransmit, chanend qAVB);

--- a/app_avb_bridge/src/queue.xc
+++ b/app_avb_bridge/src/queue.xc
@@ -1,0 +1,10 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include "queue.h"
+
+void queueManager(chanend qLeft, chanend qRight,
+                  chanend qTransmit, chanend qAVB) {
+}

--- a/app_avb_bridge/src/transmitter.h
+++ b/app_avb_bridge/src/transmitter.h
@@ -1,0 +1,6 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+void transmitter(chanend qTransmit, chanend cOutLeft, chanend cOutRight);

--- a/app_avb_bridge/src/transmitter.xc
+++ b/app_avb_bridge/src/transmitter.xc
@@ -1,0 +1,9 @@
+// Copyright (c) 2012, XMOS Ltd, All rights reserved
+// This software is freely distributable under a derivative of the
+// University of Illinois/NCSA Open Source License posted in
+// LICENSE.txt and at <http://github.xcore.com/>
+
+#include "transmitter.h"
+
+void transmitter(chanend qTransmit, chanend cOutLeft, chanend cOutRight) {
+}

--- a/app_smi_test/Makefile
+++ b/app_smi_test/Makefile
@@ -1,6 +1,6 @@
-TARGET = XK-1
+TARGET = xp-skc-l2-single
 APP_NAME = 
-XCC_FLAGS = -g -O2
+XCC_FLAGS = -g -O2 -DSMI_MDC_BIT=1 -DSMI_MDIO_BIT=0
 USED_MODULES = module_ethernet_smi
 
 

--- a/app_smi_test/src/main.xc
+++ b/app_smi_test/src/main.xc
@@ -14,11 +14,10 @@
 
 #define ETHCORE 0
 
-on stdcore[ETHCORE]: smi_interface_t smi = { 0, XS1_PORT_1M, XS1_PORT_1N };
+on stdcore[ETHCORE]: smi_interface_t smi0 = { 0x80000000, XS1_PORT_8A, XS1_PORT_4C };
+on stdcore[ETHCORE]: smi_interface_t smi1 = { 0, XS1_PORT_1M, XS1_PORT_1N };
 
-on stdcore[ETHCORE]: clock clk_smi = XS1_CLKBLK_1;
-
-void smiTest() {
+void smiTest(smi_interface_t &smi) {
     timer tmr;
     int resetTime;
 
@@ -26,15 +25,18 @@ void smiTest() {
     resetTime += 50000000;
     tmr when timerafter(resetTime) :> void;
 
-    smi_port_init(clk_smi, smi);
-    for(int i = 0; i < 32; i++) {
+    smiInit(smi);
+    while(1) {
+        timer t;
+        int t0, t1;
         int v2, v3, v18;
-        smi.phy_address = i;
+    t :> t0;
         v2 = smi_reg(smi, 2, 0, 1);
+    t :> t1;
         v3 = smi_reg(smi, 3, 0, 1);
         v18 = smi_reg(smi, 18, 0, 1);
         if ((v2 & v3 & v18) != 0xffff) {
-            printf("Phy addr %02x: reg 2, 3, 18: %04x %04x %04x\n", i, v2, v3, v18);
+            printf("Phy addr %06x: reg 2, 3, 18: %04x %04x %04x, %d ref clocks\n", eth_phy_id(smi), v2, v3, v18, t1-t0);
         }
     }
 }
@@ -42,7 +44,14 @@ void smiTest() {
 
 int main() {
     par {
-        on stdcore[ETHCORE]: smiTest();
+        on stdcore[ETHCORE]: smiTest(smi1);
+        on stdcore[ETHCORE]: while(1);
+        on stdcore[ETHCORE]: while(1);
+        on stdcore[ETHCORE]: while(1);
+        on stdcore[ETHCORE]: while(1);
+        on stdcore[ETHCORE]: while(1);
+        on stdcore[ETHCORE]: while(1);
+        on stdcore[ETHCORE]: while(1);
     }
 	return 0;
 }

--- a/app_smi_test/src/xp-skc-l2-single.xn
+++ b/app_smi_test/src/xp-skc-l2-single.xn
@@ -1,0 +1,114 @@
+<? xml version =" 1.0 " encoding =" UTF -8 "?>
+
+<Network xmlns="http://www.xmos.com"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.xmos.com http://www.xmos.com" >
+        
+    <Declarations>
+        <Declaration>core stdcore[2]</Declaration>
+    </Declarations>
+    
+    
+    <Packages>
+        <Package Id="0" Type="XS1-L2A-QF124" >
+            <Nodes>
+                <Node Id="0" InPackageId="0" Type="XS1-L1A" Oscillator="25MHz" SystemFrequency="500MHz">
+                    <Boot>
+                        <Source Location="SPI:bootFlash" />
+                        <Bootee NodeId="1" Core="0"/>
+                    </Boot>
+                    <Core Number="0" Reference="stdcore[0]">
+                        <Port Location="XS1_PORT_1A" Name="PORT_SPI_MISO"/>
+                        <Port Location="XS1_PORT_1B" Name="PORT_SPI_SS"/>
+                        <Port Location="XS1_PORT_1C" Name="PORT_SPI_CLK"/>
+                        <Port Location="XS1_PORT_1D" Name="PORT_SPI_MOSI"/>
+                        <Port Location="XS1_PORT_8D" Name="PORT_SPI_DISABLE"/>
+
+                        <Port Location="XS1_PORT_1B" Name="PORT_ETH_RXCLK_0"/>
+                        <Port Location="XS1_PORT_4A" Name="PORT_ETH_RXD_0"/>
+                        <Port Location="XS1_PORT_4B" Name="PORT_ETH_TXD_0"/>
+                        <Port Location="XS1_PORT_1C" Name="PORT_ETH_RXDV_0"/>
+                        <Port Location="XS1_PORT_1F" Name="PORT_ETH_TXEN_0"/>
+                        <Port Location="XS1_PORT_1G" Name="PORT_ETH_TXCLK_0"/>
+                        <Port Location="XS1_PORT_4C" Name="PORT_ETH_MDIOC_0"/>
+                        <Port Location="XS1_PORT_8A" Name="PORT_ETH_MDIOFAKE_0"/>
+                        <Port Location="XS1_PORT_4D" Name="PORT_ETH_INT_ERR_0"/>
+
+                        <Port Location="XS1_PORT_1J" Name="PORT_ETH_RXCLK_1"/>
+                        <Port Location="XS1_PORT_4E" Name="PORT_ETH_RXD_1"/>
+                        <Port Location="XS1_PORT_4F" Name="PORT_ETH_TXD_1"/>
+                        <Port Location="XS1_PORT_1K" Name="PORT_ETH_RXDV_1"/>
+                        <Port Location="XS1_PORT_1L" Name="PORT_ETH_TXEN_1"/>
+                        <Port Location="XS1_PORT_1I" Name="PORT_ETH_TXCLK_1"/>
+                        <Port Location="XS1_PORT_1M" Name="PORT_ETH_MDIO_1"/>
+                        <Port Location="XS1_PORT_1N" Name="PORT_ETH_MDC_1"/>
+                        <Port Location="XS1_PORT_1O" Name="PORT_ETH_INT_1"/>
+                        <Port Location="XS1_PORT_1P" Name="PORT_ETH_ERR_1"/>
+                    </Core>
+                </Node>
+                <Node Id="1" InPackageId="1" Type="XS1-L1A" Oscillator="25MHz" SystemFrequency="500MHz">
+                    <Boot>
+                        <Source Location="XMOSLINK"/>
+                    </Boot>
+                    <Core Number="0" Reference="stdcore[1]">
+                        <Port Location="XS1_PORT_1B" Name="PORT_ETH_RXCLK_2"/>
+                        <Port Location="XS1_PORT_4A" Name="PORT_ETH_RXD_2"/>
+                        <Port Location="XS1_PORT_4B" Name="PORT_ETH_TXD_2"/>
+                        <Port Location="XS1_PORT_1C" Name="PORT_ETH_RXDV_2"/>
+                        <Port Location="XS1_PORT_1F" Name="PORT_ETH_TXEN_2"/>
+                        <Port Location="XS1_PORT_1G" Name="PORT_ETH_TXCLK_2"/>
+                        <Port Location="XS1_PORT_4C" Name="PORT_ETH_MDIOC_2"/>
+                        <Port Location="XS1_PORT_8A" Name="PORT_ETH_MDIOFAKE_2"/>
+                        <Port Location="XS1_PORT_4D" Name="PORT_ETH_INT_ERR_2"/>
+
+                        <Port Location="XS1_PORT_1J" Name="PORT_ETH_RXCLK_3"/>
+                        <Port Location="XS1_PORT_4E" Name="PORT_ETH_RXD_3"/>
+                        <Port Location="XS1_PORT_4F" Name="PORT_ETH_TXD_3"/>
+                        <Port Location="XS1_PORT_1K" Name="PORT_ETH_RXDV_3"/>
+                        <Port Location="XS1_PORT_1L" Name="PORT_ETH_TXEN_3"/>
+                        <Port Location="XS1_PORT_1I" Name="PORT_ETH_TXCLK_3"/>
+                        <Port Location="XS1_PORT_8D" Name="PORT_ETH_MDIOC_3"/>
+                        <Port Location="XS1_PORT_1M" Name="PORT_ETH_MDIO_3"/>
+                        <Port Location="XS1_PORT_1N" Name="PORT_ETH_MDC_3"/>
+                        <Port Location="XS1_PORT_1O" Name="PORT_ETH_INT_3"/>
+                        <Port Location="XS1_PORT_1P" Name="PORT_ETH_ERR_3"/>
+                    </Core>
+                </Node>
+            </Nodes>
+        </Package> 
+    </Packages>
+
+    <Links>
+        <Link Encoding="5wire" Delays="0,1">
+            <LinkEndpoint NodeId="0" Link="XLG"/>
+            <LinkEndpoint NodeId="1" Link="XLF"/>
+        </Link>
+        <Link Encoding="5wire" Delays="0,1">
+            <LinkEndpoint NodeId="0" Link="XLH"/>
+            <LinkEndpoint NodeId="1" Link="XLE"/>
+        </Link>
+        <Link Encoding="5wire" Delays="0,1">
+            <LinkEndpoint NodeId="0" Link="XLE"/>
+            <LinkEndpoint NodeId="1" Link="XLH"/>
+        </Link>
+        <Link Encoding="5wire" Delays="0,1">
+            <LinkEndpoint NodeId="0" Link="XLF"/>
+            <LinkEndpoint NodeId="1" Link="XLG"/>
+        </Link>
+    </Links>
+  
+    <ExternalDevices>
+        <Device NodeId="0" Core="0" Name="bootFlash" Class="SPIFlash" Type="M25P16">
+            <Attribute Name="PORT_SPI_MISO" Value="PORT_SPI_MISO" />
+            <Attribute Name="PORT_SPI_SS" Value="PORT_SPI_SS" />
+            <Attribute Name="PORT_SPI_CLK" Value="PORT_SPI_CLK" />
+            <Attribute Name="PORT_SPI_MOSI" Value="PORT_SPI_MOSI" />
+        </Device>
+    </ExternalDevices>
+
+    <JTAGChain>
+        <JTAGDevice NodeId="0"/>
+        <JTAGDevice NodeId="1"/>
+    </JTAGChain>
+
+</Network>

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,4 +9,4 @@ XMOS Ethernet Component
    programming
    api
    singlethread
-
+   smi

--- a/doc/smi.rst
+++ b/doc/smi.rst
@@ -1,0 +1,50 @@
+module_ethernet_smi API
+=======================
+
+This module is written to support SMI independently of the MII interface.
+Typically, Ethernet PHYs are configured on reset automatically, but the SMI
+interface may be useful for setting and testing register values
+dynamically. 
+
+There are two ways to interface SMI: using a pair of 1-bit ports, or using
+a single multi-bit port.
+
+Configuration Defines
+---------------------
+
+Two defines can be defined on the command line:
+
+**SMI_MDC_BIT**
+
+    This defines the bit number on the shared port where the MDC line is.
+    Only define this if you have a port that drives both MDC and MDIO.
+
+**SMI_MDIO_BIT**
+
+    This defines the bit number on the shared port where the MDIO line is.
+    Only define this if you have a port that drives both MDC and MDIO.
+
+
+Data Structures
+---------------
+
+.. doxygenstruct:: smi_interface_t
+
+
+Phy API
+-------
+
+.. doxygenfunction:: smiInit
+
+.. doxygenfunction:: eth_phy_config
+
+.. doxygenfunction:: eth_phy_config_noauto
+
+.. doxygenfunction:: eth_phy_loopback
+
+.. doxygenfunction:: eth_phy_id
+
+.. doxygenfunction:: smiCheckLinkState
+
+.. doxygenfunction:: smi_reg
+

--- a/module_ethernet_smi/src/smi.h
+++ b/module_ethernet_smi/src/smi.h
@@ -11,31 +11,36 @@
 
 /** Structure containing resources required for the SMI ethernet phy interface.
  *
- * This structure contains the resources required to communicate with
- * an ethernet phy over smi. 
- *   
- **/
+ * This structure can be filled in two ways. One indicate that the SMI
+ * interface is connected using two 1-bit port, the other indicates that
+ * the interface is connected using a single multi-bit port.
+ *
+ * If used with two 1-bit ports, set the ``phy_address``, ``p_smi_mdio_``
+ * and ``p_smi_mdc`` as normal.
+ *
+ * If used with a single multi-bit port, then you must set bit 31 of
+ * phy_address to 1 to indicate that this is a shared MDIO and MDC port.
+ * MDIO port should be set to an unused port, MDC port should be
+ * set to the shared port.
+ *
+ * The code to deal with a single multi-bit port is not included by
+ * default. To include it you must define SMI_MDC_BIT and SMI_MDIO_BIT, and
+ * they should be set to the pin numbers (0..31) in the multi-bit port.
+ */
 typedef struct smi_interface_t {
-    int phy_address;           /**< Address of PHY, typically 0 or 0x1F.
-                                * Set bit 31 of phy_address to 1 to
-                                * indicate that this is a shared MDIO and
-                                * MDC port. MDIO port should be set to some
-                                * random unused port, MDC port should be
-                                * set to the shared port. SMI_MDC_BIT and
-                                * SMI_MDIO_BIT should be defined to
-                                * indicate which bits are used. */
+    int phy_address;           /**< Address of PHY, typically 0 or 0x1F. */
     port p_smi_mdio;           /**< MDIO port. */
     port p_smi_mdc;            /**< MDC port.  */
 } smi_interface_t;
 
-/** Function that configures the SMI ports. Needs a clock block that it
- * connects up to the ports. Note that there is no deinit function.
- *
- * \param clk_smi clock block used to clock the SMI pins.
+/** Function that configures the SMI ports. No clock block is needed.
+ * Note that there is no deinit function.
  *
  * \param smi structure containing the clock and data ports for SMI.
  */
-void smi_port_init(clock clk_smi, smi_interface_t &smi);
+void smiInit(smi_interface_t &smi);
+
+#define smi_port_init(clk,smi) _Pragma("warning \"smi_port_init in module_ethernet_smi deprecated, use smiInit without clock block\"") smiInit(smi)
 
 /** Function that configures the Ethernet PHY explicitly to set to
  * autonegotiate.


### PR DESCRIPTION
This version has taken the clock block out of the SMI component. Important for supporting multiple SMI/MII interfaces on a single core.
