### PR TITLE
Added elimination block directive in single threaded version

### DIFF
--- a/module_mii_singlethread/src/miiClientInterrupt.S
+++ b/module_mii_singlethread/src/miiClientInterrupt.S
@@ -1,3 +1,4 @@
+.cc_top miiInstallHandler.func, miiInstallHandler
 // Copyright (c) 2011, XMOS Ltd, All rights reserved
 // This software is freely distributable under a derivative of the
 // University of Illinois/NCSA Open Source License posted in
@@ -122,3 +123,4 @@ returnFromInterrupt:
     
     kret
 
+.cc_bottom miiInstallHandler.func

--- a/module_mii_singlethread/src/miiLLD.S
+++ b/module_mii_singlethread/src/miiLLD.S
@@ -1,4 +1,5 @@
-#include <xs1.h>
+.cc_top miiLLD.func, miiLLD
+    #include <xs1.h>
     // Two coroutines, IN  and OUT. The IN coroutine is jumped to on an IN event.
     // The OUT coroutine is jumped to from IN by jumping to R3.
     // The IN event vectors on the RXD/RXDV ports, and change the vectors depending on the
@@ -343,3 +344,4 @@ tailValues:
 .set      tailValues.globound,4
     
     .text
+.cc_bottom miiLLD.func


### PR DESCRIPTION
Required if single threaded ethernet is used in a multi core application.
