### PR TITLE
Remove mii_single_server().

### DIFF
--- a/module_ethernet/src/lite/mii_single_server.xc
+++ b/module_ethernet/src/lite/mii_single_server.xc
@@ -99,28 +99,6 @@ static void the_server(chanend cIn, chanend cOut, chanend cNotifications,
     } 
 }
 
-
-void mii_single_server(out port ?p_mii_resetn,
-                     smi_interface_t &?smi,
-                     mii_interface_lite_t &m,
-                     chanend appIn, chanend appOut,
-                     unsigned char mac_address[6]) {
-    chan cIn, cOut;
-    chan notifications;
-	mii_initialise(p_mii_resetn, m);
-#ifndef MII_NO_SMI_CONFIG
-        if (!isnull(smi)) {
-          smi_init(smi);
-          eth_phy_config(1, smi);
-        }
-#endif
-    par {
-      {asm(""::"r"(notifications));mii_driver(m, cIn, cOut);}
-        the_server(cIn, cOut, notifications, smi, appIn, appOut, mac_address);
-    }
-
-}
-
 void ethernet_server_lite(mii_interface_lite_t &m,
                           smi_interface_t &?smi,
                           char mac_address[6],


### PR DESCRIPTION
This isn't exposed in any header file and none of the example apps use it
so I assume it can be safely removed.

It may make sense to rename this file but I'll leave that up to you.
