### PR TITLE
Fix ethernet_server_lite prototype to match definition.

### DIFF
--- a/module_ethernet/src/include/ethernet_server_lite.h
+++ b/module_ethernet/src/include/ethernet_server_lite.h
@@ -14,7 +14,7 @@
 
 void ethernet_server_lite(mii_interface_lite_t &mii,
                           smi_interface_t &?smi,
-                          char mac_address[],
+                          char mac_address[6],
                           chanend rx[],
                           int num_rx,
                           chanend tx[],

--- a/module_ethernet/src/lite/mii_single_server.xc
+++ b/module_ethernet/src/lite/mii_single_server.xc
@@ -3,7 +3,7 @@
 // University of Illinois/NCSA Open Source License posted in
 // LICENSE.txt and at <http://github.xcore.com/>
 
-
+#include "ethernet_server_lite.h"
 #include <xs1.h>
 #include <xclib.h>
 #include <print.h>


### PR DESCRIPTION
Add appropriate header file so a prototype mismatches will be detected at
compile time in future.

Note the next tools release will detect the prototype mismatch as an error at link time.
